### PR TITLE
Update Audi Q2: Add Wikipedia references and fix README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi Q2
 
+This repository contains signal set configurations for the Audi Q2, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q2"
+
 generations:
   - name: "First Generation (GA)"
     start_year: 2016


### PR DESCRIPTION
- Added: Wikipedia reference to generations.yaml
- Updated: README.md title from placeholder to "Audi Q2"

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
